### PR TITLE
fix: update sidebar buttons for RuneLite FlatLaf

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ Coming Soon:
 
 ## Changes
 
+#### 2.4
+
+* Update Side Panel for RuneLite's new Look and Feel (FlatLaf)
+
 #### 2.3
 * Fix issue where Verzik mistakes were not being detected
 

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ dependencies {
 }
 
 group = 'com.tobmistaketracker'
-version = '2.3'
+version = '2.4'
 sourceCompatibility = '1.8'
 
 tasks.withType(JavaCompile) {

--- a/src/main/java/com/tobmistaketracker/panel/TobMistakeTrackerPanel.java
+++ b/src/main/java/com/tobmistaketracker/panel/TobMistakeTrackerPanel.java
@@ -144,9 +144,8 @@ public class TobMistakeTrackerPanel extends PluginPanel {
         leftTitleContainer.add(currentViewTitle, BorderLayout.WEST);
 
         // Create the switch view button
-        SwingUtil.removeButtonDecorations(switchMistakesViewBtn);
         switchMistakesViewBtn.setText(getSwitchMistakesViewButtonText());
-        switchMistakesViewBtn.setBackground(Color.WHITE);
+        switchMistakesViewBtn.setBackground(Color.DARK_GRAY);
         switchMistakesViewBtn.setBorder(new EmptyBorder(10, 10, 10, 10));
         switchMistakesViewBtn.setBorderPainted(true);
         switchMistakesViewBtn.setPreferredSize(new Dimension(100, 10));
@@ -155,13 +154,11 @@ public class TobMistakeTrackerPanel extends PluginPanel {
         switchMistakesViewBtn.addActionListener(e -> switchMistakesView());
         switchMistakesViewBtn.addMouseListener(new MouseAdapter() {
             public void mouseEntered(MouseEvent e) {
-                switchMistakesViewBtn.setForeground(Color.LIGHT_GRAY);
-                switchMistakesViewBtn.setBackground(Color.LIGHT_GRAY);
+                switchMistakesViewBtn.setBackground(Color.GRAY);
             }
 
             public void mouseExited(MouseEvent e) {
-                switchMistakesViewBtn.setForeground(Color.WHITE);
-                switchMistakesViewBtn.setBackground(Color.WHITE);
+                switchMistakesViewBtn.setBackground(Color.DARK_GRAY);
             }
         });
 


### PR DESCRIPTION
updates the button color that switches the Mistakes View to be properly visible with RuneLite's new Look and Feel (FlatLaf). Related to QuestingPet/ToaMistakeTracker#10